### PR TITLE
Ensure the plan text is in a consistent place.

### DIFF
--- a/gh_actions/attach_plan_to_pr/README.md
+++ b/gh_actions/attach_plan_to_pr/README.md
@@ -46,7 +46,7 @@ The terraform plan in human-readable output
 
 ```yaml
       - name: Build Terraform Plan
-        uses: RSS-Engineering/terraform/gh_actions/attach_plan_to_pr@v1.1.1
+        uses: RSS-Engineering/terraform/gh_actions/attach_plan_to_pr@v1.1.2
         id: plan
         env:
           ENV: prod
@@ -56,7 +56,7 @@ The terraform plan in human-readable output
         with:
           terraform_version: 1.0.1
           root: infrastructure/environments/prod
-          text_artifact_name: tf-plan-${{ github.event.after }}.txt
-          plan_artifact_name: tf-plan-${{ github.event.after }}
+          text_artifact_name: tf-plan-${{ github.sha }}.txt
+          plan_artifact_name: tf-plan-${{ github.sha }}
 ```
 

--- a/gh_actions/attach_plan_to_pr/action.yml
+++ b/gh_actions/attach_plan_to_pr/action.yml
@@ -90,7 +90,7 @@ runs:
       shell: bash
       env:
         PLAN: "${{ steps.plan.outputs.stdout }}"
-      run: echo "${PLAN}" >> tf-plan-${{ github.sha }}.txt
+      run: echo "${PLAN}" >> ${{ inputs.text_artifact_name }}
 
     - name: Save Terraform Plan Text
       if: inputs.text_artifact_name != '' && steps.plan.outcome == 'success'


### PR DESCRIPTION
This is to fix a bug where the text artifact wouldn't save when the plan didn't go to a PR.