### PR TITLE
Boolean check inputs.add_plan_to_pr == 'true' for plan o/p.

### DIFF
--- a/gh_actions/attach_plan_to_pr/action.yml
+++ b/gh_actions/attach_plan_to_pr/action.yml
@@ -103,7 +103,7 @@ runs:
         retention-days: 7
 
     - uses: actions/github-script@0.9.0
-      if: steps.plan.outcome == 'success' && inputs.add_plan_to_pr && github.event_name == 'pull_request' && !contains(steps.plan.outputs.stdout, inputs.ignore_plan_phrase)
+      if: steps.plan.outcome == 'success' && inputs.add_plan_to_pr == 'true' && github.event_name == 'pull_request' && !contains(steps.plan.outputs.stdout, inputs.ignore_plan_phrase)
       env:
         PLAN: "${{ steps.plan.outputs.stdout }}"
       with:


### PR DESCRIPTION
Facing issues in not outputting the plan in Pr when add_plan_to_pr set to 'false' in the PR. 


Adding check inputs.add_plan_to_pr == 'true' for plan output block.

Please see
https://github.com/actions/runner/issues/1483