### PR TITLE
Allow secrets to be saved to SSM Parameter Store

### DIFF
--- a/docs/modules/kms_secrets.md
+++ b/docs/modules/kms_secrets.md
@@ -30,6 +30,10 @@ module "secrets" {
 
 Storing secrets in SecretsManager is as easy as providing `secretsmanager_key` that will be used to reference them at run-time.
 
+### Storing secrets in SSM Parameter Store
+
+If you provide the `ssm_parameter_prefix` argument to the module, the secrets will be saved to SSM Parameter Store with the given prefix, using `key` as the name.
+
 ## Argument Reference
 
 ---
@@ -45,18 +49,18 @@ The following arguments are supported:
   > **Note**: This KMS Key must exist apart from this module to avoid a circular-dependency situation. If you choose to manage your KMS keys that you reference here with Terraform, it is highly recommended to set the `prevent_destroy` lifecycle attribute.
 
   * `ciphertext` - The base64-encoded ciphertext of the secret.
-  
+
     Each secret must be encrypted at development time with the pre-created customer-managed KMS key that is referenced in `kms_key_id`.
-  
+
     1. Write your desired secret in a plaintext file locally:
       ```bash
       echo -n 'master-password' > plaintext-password
       ```
-      
-      > **Note**: Use this method exactly to avoid a more advanced editor potentially applying a _newline_ at the end of the file. 
-    
+
+      > **Note**: Use this method exactly to avoid a more advanced editor potentially applying a _newline_ at the end of the file.
+
     2. Use the AWS CLI to encrypt your secret:
-  
+
       ```bash
       aws kms encrypt --key-id {kms_key_id} --plaintext fileb://plaintext-password --encryption-context environment=dev --output text --query CiphertextBlob
       ```
@@ -65,7 +69,9 @@ The following arguments are supported:
     3. The output of the previous step is the value to use for `ciphertext`.
 
 
-  * `secretsmanager_key` - (Optional) A string value key used to save a hash of the `secrets` in SecretsManager in order to access the secrets after deployment. 
+  * `secretsmanager_key` - (Optional) A string value key used to save a hash of the `secrets` in SecretsManager in order to access the secrets after deployment.
+
+  * `ssm_parameter_prefix` - (Optional) A string value without trailing hashes representing the prefix under which the secrets should be saved into SSM Parameter Store (the resulting parameter name will be: `<ssm_parameter_prefix>/<key>`)
 
 ## Attributes Reference
 
@@ -74,7 +80,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `plaintext` - A map of each secret key to its decrypted value for use in other resources attributes. This attribute is marked as _sensitive_ to prevent it from appearing in plaintext in console output.
-  
+
     Example usage:
 
     ```terraform

--- a/modules/kms_secrets/main.tf
+++ b/modules/kms_secrets/main.tf
@@ -35,3 +35,11 @@ resource "aws_secretsmanager_secret_version" "this" {
   secret_id     = aws_secretsmanager_secret.this[0].id
   secret_string = jsonencode(local.secrets_map)
 }
+
+resource "aws_ssm_parameter" "this" {
+  count = var.ssm_parameter_prefix == "" ? 0 : length(var.secrets)
+
+  name  = "${var.ssm_parameter_prefix}/${var.secrets[count.index].key}"
+  type  = "SecureString"
+  value = local.secrets_map[var.secrets[count.index].key]
+}

--- a/modules/kms_secrets/variables.tf
+++ b/modules/kms_secrets/variables.tf
@@ -34,3 +34,9 @@ variable "description" {
 variable "context" {
   type = map(string)
 }
+
+variable "ssm_parameter_prefix" {
+  type        = string
+  description = "Provide a parameter prefix to store the secrets in SSM Parameter Store"
+  default     = ""
+}


### PR DESCRIPTION
A new argument to the `kms_secrets` module allows anyone to easily save the secrets into SSM Parameter Store.