### PR TITLE
Datadog AWS Integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,11 @@ module "secrets" {
 Terraform good practice is to specify a commit hash when sourcing an external module to prevent module changes from unexpectly breaking your deployment pipeline.
 
 ---
+### [datadog_aws_integration](modules/datadog_aws_integration.md)
+
+The [datadog_aws_integration](modules/datadog_aws_integration.md) module creates the required IAM roles and polices for Datadog to integrate with your AWS account. It will also create the aws integration in datadog.
+
 ### [kms_secrets](modules/kms_secrets.md)
 
 The [kms_secrets](modules/kms_secrets.md) module allows you to store multiple secrets in your repository in encrypted form. This provides secrets that terraform can use without needing them to be stored and managed in a separate secure store such as PasswordSafe, SecretsManager or as an SSM Param.
+

--- a/docs/modules/datadog_aws_integration.md
+++ b/docs/modules/datadog_aws_integration.md
@@ -21,6 +21,11 @@ module "datadog_aws_integration" {
     "service" : "Application",
     "env" : "production",
   }
+  namespace_rules = {
+    "api_gateway" : true,
+    "cloudfront" : true,
+    "cloudwatch_events" : true
+  }
 }
 ```
 
@@ -33,3 +38,4 @@ The following arguments are supported:
 * `app_key` - Datadog integration App key
 * `api_key` - (sensitive) Datadog integration API key
 * `host_tags` - A map of strings to be applied as tags to each metric ingested through this integration. The key-value pair will be converted to a single tag formatted like "{k}:{v}"
+* `namespace_rules` - Specifically enables or disables metric collection for specific AWS namespaces for this _AWS account only_. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/v1/aws-integration/#list-namespace-rules).

--- a/docs/modules/datadog_aws_integration.md
+++ b/docs/modules/datadog_aws_integration.md
@@ -12,7 +12,7 @@
 module "datadog_aws_integration" {
   source = "github.com/RSS-Engineering/terraform.git?ref={commit}/modules/datadog_aws_integration"
 
-  app_key = "app_key_from_datadog_console"
+  app_key = module.secrets.plaintext["datadog_app_key"] # Recommended to use the kms_secrets module here
   api_key = module.secrets.plaintext["datadog_api_key"] # Recommended to use the kms_secrets module here
   
   host_tags = {
@@ -35,7 +35,7 @@ module "datadog_aws_integration" {
 
 The following arguments are supported:
 
-* `app_key` - Datadog integration App key
+* `app_key` - (sensitive) Datadog integration App key
 * `api_key` - (sensitive) Datadog integration API key
-* `host_tags` - A map of strings to be applied as tags to each metric ingested through this integration. The key-value pair will be converted to a single tag formatted like "{k}:{v}"
-* `namespace_rules` - Specifically enables or disables metric collection for specific AWS namespaces for this _AWS account only_. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/v1/aws-integration/#list-namespace-rules).
+* `host_tags` - (optional) A map of strings to be applied as tags to each metric ingested through this integration. The key-value pair will be converted to a single tag formatted like "{k}:{v}"
+* `namespace_rules` - (optional) Specifically enables or disables metric collection for specific AWS namespaces for this _AWS account only_. A list of namespaces can be found at the [available namespace rules API endpoint](https://docs.datadoghq.com/api/v1/aws-integration/#list-namespace-rules). Omitting a namespace will not change it from the default integration settings.

--- a/docs/modules/datadog_aws_integration.md
+++ b/docs/modules/datadog_aws_integration.md
@@ -1,0 +1,35 @@
+# datadog_aws_integration
+
+**datadog_aws_integration** Creates the required IAM roles and polices for Datadog to integrate with your AWS account. It will also create the aws integration in datadog.
+
+## Example Usage
+
+---
+
+### Password secret available at build-time
+
+```terraform
+module "datadog_aws_integration" {
+  source = "github.com/RSS-Engineering/terraform.git?ref={commit}/modules/datadog_aws_integration"
+
+  app_key = "app_key_from_datadog_console"
+  api_key = module.secrets.plaintext["datadog_api_key"] # Recommended to use the kms_secrets module here
+  
+  host_tags = {
+    "account" : data.aws_caller_identity.current.account_id,
+    "region" : data.aws_region.current.name,
+    "service" : "Application",
+    "env" : "production",
+  }
+}
+```
+
+## Argument Reference
+
+---
+
+The following arguments are supported:
+
+* `app_key` - Datadog integration App key
+* `api_key` - (sensitive) Datadog integration API key
+* `host_tags` - A map of strings to be applied as tags to each metric ingested through this integration. The key-value pair will be converted to a single tag formatted like "{k}:{v}"

--- a/modules/datadog_aws_integration/conf.tf
+++ b/modules/datadog_aws_integration/conf.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "3.18.0"
+    }
+  }
+}

--- a/modules/datadog_aws_integration/main.tf
+++ b/modules/datadog_aws_integration/main.tf
@@ -3,11 +3,6 @@ data "aws_region" "current" {}
 
 # Adapted from https://docs.datadoghq.com/integrations/guide/aws-terraform-setup/
 
-provider "datadog" {
-  api_key = var.api_key
-  app_key = var.app_key
-}
-
 locals {
   integration_role_name = "DatadogAWSIntegrationRole"
 }

--- a/modules/datadog_aws_integration/main.tf
+++ b/modules/datadog_aws_integration/main.tf
@@ -136,4 +136,5 @@ resource "datadog_integration_aws" "integration" {
   host_tags = [
     for k, v in var.host_tags : "${k}:${v}"
   ]
+  account_specific_namespace_rules = var.namespace_rules
 }

--- a/modules/datadog_aws_integration/main.tf
+++ b/modules/datadog_aws_integration/main.tf
@@ -112,7 +112,6 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-
 resource "aws_iam_role" "integration_role" {
   name        = local.integration_role_name
   description = "Role for Datadog AWS Integration"

--- a/modules/datadog_aws_integration/main.tf
+++ b/modules/datadog_aws_integration/main.tf
@@ -1,0 +1,139 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# Adapted from https://docs.datadoghq.com/integrations/guide/aws-terraform-setup/
+
+provider "datadog" {
+  api_key = var.api_key
+  app_key = var.app_key
+}
+
+locals {
+  integration_role_name = "DatadogAWSIntegrationRole"
+}
+
+data "aws_iam_policy_document" "integration_policy_document" {
+  statement {
+    actions = [
+      "xray:GetTraceSummaries",
+      "xray:BatchGetTraces",
+      "tag:GetTagValues",
+      "tag:GetTagKeys",
+      "tag:GetResources",
+      "support:*",
+      "sqs:ListQueues",
+      "sns:Publish",
+      "sns:List*",
+      "ses:Get*",
+      "s3:PutBucketNotification",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketTagging",
+      "s3:GetBucketNotification",
+      "s3:GetBucketLogging",
+      "s3:GetBucketLocation",
+      "route53:List*",
+      "redshift:DescribeLoggingStatus",
+      "redshift:DescribeClusters",
+      "rds:List*",
+      "rds:Describe*",
+      "logs:TestMetricFilter",
+      "logs:PutSubscriptionFilter",
+      "logs:Get*",
+      "logs:FilterLogEvents",
+      "logs:DescribeSubscriptionFilters",
+      "logs:Describe*",
+      "logs:DeleteSubscriptionFilter",
+      "lambda:RemovePermission",
+      "lambda:List*",
+      "lambda:GetPolicy",
+      "lambda:AddPermission",
+      "kinesis:List*",
+      "kinesis:Describe*",
+      "health:DescribeEvents",
+      "health:DescribeEventDetails",
+      "health:DescribeAffectedEntities",
+      "es:ListTags",
+      "es:ListDomainNames",
+      "es:DescribeElasticsearchDomains",
+      "elasticmapreduce:List*",
+      "elasticmapreduce:Describe*",
+      "elasticloadbalancing:Describe*",
+      "elasticfilesystem:DescribeTags",
+      "elasticfilesystem:DescribeFileSystems",
+      "elasticache:List*",
+      "elasticache:Describe*",
+      "ecs:List*",
+      "ecs:Describe*",
+      "ec2:Describe*",
+      "dynamodb:List*",
+      "dynamodb:Describe*",
+      "directconnect:Describe*",
+      "codedeploy:List*",
+      "codedeploy:BatchGet*",
+      "cloudwatch:List*",
+      "cloudwatch:Get*",
+      "cloudwatch:Describe*",
+      "cloudtrail:GetTrailStatus",
+      "cloudtrail:DescribeTrails",
+      "cloudfront:ListDistributions",
+      "cloudfront:GetDistributionConfig",
+      "budgets:ViewBudget",
+      "autoscaling:Describe*",
+      "apigateway:GET"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "integration_policy" {
+  name = "DatadogAWSIntegrationPolicy"
+  path = "/"
+
+  policy = data.aws_iam_policy_document.integration_policy_document.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::464622532012:root", # Datadog's AWS account
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values = [
+        datadog_integration_aws.integration.external_id
+      ]
+    }
+  }
+}
+
+
+resource "aws_iam_role" "integration_role" {
+  name        = local.integration_role_name
+  description = "Role for Datadog AWS Integration"
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_integration_policy" {
+  role       = aws_iam_role.integration_role.name
+  policy_arn = aws_iam_policy.integration_policy.arn
+}
+
+resource "datadog_integration_aws" "integration" {
+  account_id = data.aws_caller_identity.current.account_id
+  role_name  = local.integration_role_name
+  host_tags = [
+    for k, v in var.host_tags : "${k}:${v}"
+  ]
+}

--- a/modules/datadog_aws_integration/output.tf
+++ b/modules/datadog_aws_integration/output.tf
@@ -1,0 +1,3 @@
+output "external_id" {
+  value = datadog_integration_aws.integration.external_id
+}

--- a/modules/datadog_aws_integration/variables.tf
+++ b/modules/datadog_aws_integration/variables.tf
@@ -1,17 +1,3 @@
-variable "app_key" {
-  type        = string
-  description = "Datadog integration app key"
-
-  sensitive = true
-}
-
-variable "api_key" {
-  type        = string
-  description = "Datadog integration API key"
-
-  sensitive = true
-}
-
 variable "host_tags" {
   type        = map(string)
   description = "Tags to be added to all metrics read through this integration"

--- a/modules/datadog_aws_integration/variables.tf
+++ b/modules/datadog_aws_integration/variables.tf
@@ -16,3 +16,11 @@ variable "host_tags" {
 
   default = {}
 }
+
+variable "namespace_rules" {
+  # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws#account_specific_namespace_rules
+  type = map(bool)
+  description = "Enables or disables metric collection for specific AWS namespaces for this AWS account only"
+
+  default = {}
+}

--- a/modules/datadog_aws_integration/variables.tf
+++ b/modules/datadog_aws_integration/variables.tf
@@ -1,6 +1,8 @@
 variable "app_key" {
   type        = string
   description = "Datadog integration app key"
+
+  sensitive = true
 }
 
 variable "api_key" {

--- a/modules/datadog_aws_integration/variables.tf
+++ b/modules/datadog_aws_integration/variables.tf
@@ -1,0 +1,18 @@
+variable "app_key" {
+  type        = string
+  description = "Datadog integration app key"
+}
+
+variable "api_key" {
+  type        = string
+  description = "Datadog integration API key"
+
+  sensitive = true
+}
+
+variable "host_tags" {
+  type        = map(string)
+  description = "Tags to be added to all metrics read through this integration"
+
+  default = {}
+}


### PR DESCRIPTION
The purpose of this plugin is to help project get jump-started integrating with Datadog.


Easy-to-read documentation here: https://github.com/RSS-Engineering/terraform/blob/datadog/docs/README.md and https://github.com/RSS-Engineering/terraform/blob/datadog/docs/modules/datadog_aws_integration.md