### PR TITLE
fix(modules/kms_secrets): use custom kms for ssm params

### DIFF
--- a/docs/modules/kms_secrets.md
+++ b/docs/modules/kms_secrets.md
@@ -40,38 +40,37 @@ If you provide the `ssm_parameter_prefix` argument to the module, the secrets wi
 
 The following arguments are supported:
 
-* `context` - (Optional) A map used to encrypt/decrypt the ciphertext. This must be the same as what is provided to encrypt the secrets.
-* `secrets` - A list of objects each with:
+- `context` - (Optional) A map used to encrypt/decrypt the ciphertext. This must be the same as what is provided to encrypt the secrets.
+- `secretsmanager_key` - (Optional) A string value key used to save a hash of the `secrets` in SecretsManager in order to access the secrets after deployment.
+- `ssm_parameter_prefix` - (Optional) A string value without trailing hashes representing the prefix under which the secrets should be saved into SSM Parameter Store (the resulting parameter name will be: `<ssm_parameter_prefix>/<key>`)
+- `secrets` - A list of objects each with:
 
-  * `key` - A plaintext string value used to reference this secret.
-  * `kms_key_id` - The KMS key id used to encrypt/decrypt this secret.
+  - `key` - A plaintext string value used to reference this secret.
+  - `kms_key_id` - The KMS key id used to encrypt/decrypt this secret.
 
   > **Note**: This KMS Key must exist apart from this module to avoid a circular-dependency situation. If you choose to manage your KMS keys that you reference here with Terraform, it is highly recommended to set the `prevent_destroy` lifecycle attribute.
 
-  * `ciphertext` - The base64-encoded ciphertext of the secret.
+  - `ciphertext` - The base64-encoded ciphertext of the secret.
 
     Each secret must be encrypted at development time with the pre-created customer-managed KMS key that is referenced in `kms_key_id`.
 
     1. Write your desired secret in a plaintext file locally:
-      ```bash
-      echo -n 'master-password' > plaintext-password
-      ```
 
-      > **Note**: Use this method exactly to avoid a more advanced editor potentially applying a _newline_ at the end of the file.
+    ```bash
+    echo -n 'master-password' > plaintext-password
+    ```
+
+    > **Note**: Use this method exactly to avoid a more advanced editor potentially applying a _newline_ at the end of the file.
 
     2. Use the AWS CLI to encrypt your secret:
 
-      ```bash
-      aws kms encrypt --key-id {kms_key_id} --plaintext fileb://plaintext-password --encryption-context environment=dev --output text --query CiphertextBlob
-      ```
-      > **Note**: The _encryption-context_ provided here must match the _context_ property provided to the kms_secrets module.
+    ```bash
+    aws kms encrypt --key-id {kms_key_id} --plaintext fileb://plaintext-password --encryption-context environment=dev --output text --query CiphertextBlob
+    ```
+
+    > **Note**: The _encryption-context_ provided here must match the _context_ property provided to the kms_secrets module.
 
     3. The output of the previous step is the value to use for `ciphertext`.
-
-
-  * `secretsmanager_key` - (Optional) A string value key used to save a hash of the `secrets` in SecretsManager in order to access the secrets after deployment.
-
-  * `ssm_parameter_prefix` - (Optional) A string value without trailing hashes representing the prefix under which the secrets should be saved into SSM Parameter Store (the resulting parameter name will be: `<ssm_parameter_prefix>/<key>`)
 
 ## Attributes Reference
 
@@ -79,10 +78,10 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `plaintext` - A map of each secret key to its decrypted value for use in other resources attributes. This attribute is marked as _sensitive_ to prevent it from appearing in plaintext in console output.
+- `plaintext` - A map of each secret key to its decrypted value for use in other resources attributes. This attribute is marked as _sensitive_ to prevent it from appearing in plaintext in console output.
 
-    Example usage:
+  Example usage:
 
-    ```terraform
-    module.secrets.plaintext["password"]
-    ```
+  ```terraform
+  module.secrets.plaintext["password"]
+  ```

--- a/docs/modules/kms_secrets.md
+++ b/docs/modules/kms_secrets.md
@@ -43,6 +43,7 @@ The following arguments are supported:
 - `context` - (Optional) A map used to encrypt/decrypt the ciphertext. This must be the same as what is provided to encrypt the secrets.
 - `secretsmanager_key` - (Optional) A string value key used to save a hash of the `secrets` in SecretsManager in order to access the secrets after deployment.
 - `ssm_parameter_prefix` - (Optional) A string value without trailing hashes representing the prefix under which the secrets should be saved into SSM Parameter Store (the resulting parameter name will be: `<ssm_parameter_prefix>/<key>`)
+- `use_custom_kms_key_for_ssm` - (Optional) A boolean value indicating whether to use a custom KMS key for encrypting the secrets in SSM Parameter Store. Default to `false` which means that the AWS managed SSM key for SSM Parameter Store will be used.
 - `secrets` - A list of objects each with:
 
   - `key` - A plaintext string value used to reference this secret.

--- a/modules/kms_secrets/main.tf
+++ b/modules/kms_secrets/main.tf
@@ -39,7 +39,8 @@ resource "aws_secretsmanager_secret_version" "this" {
 resource "aws_ssm_parameter" "this" {
   count = var.ssm_parameter_prefix == "" ? 0 : length(var.secrets)
 
-  name  = "${var.ssm_parameter_prefix}/${var.secrets[count.index].key}"
-  type  = "SecureString"
-  value = local.secrets_map[var.secrets[count.index].key]
+  name   = "${var.ssm_parameter_prefix}/${var.secrets[count.index].key}"
+  type   = "SecureString"
+  key_id = var.secrets[count.index].kms_key_id
+  value  = local.secrets_map[var.secrets[count.index].key]
 }

--- a/modules/kms_secrets/variables.tf
+++ b/modules/kms_secrets/variables.tf
@@ -40,3 +40,9 @@ variable "ssm_parameter_prefix" {
   description = "Provide a parameter prefix to store the secrets in SSM Parameter Store"
   default     = ""
 }
+
+variable "use_custom_kms_key_for_ssm" {
+  type        = bool
+  description = "Use the default AWS managed KMS key to encrypt the secrets in SSM Parameter Store"
+  default     = false
+}

--- a/modules/kms_secrets/variables.tf
+++ b/modules/kms_secrets/variables.tf
@@ -43,6 +43,6 @@ variable "ssm_parameter_prefix" {
 
 variable "use_custom_kms_key_for_ssm" {
   type        = bool
-  description = "Use the default AWS managed KMS key to encrypt the secrets in SSM Parameter Store"
+  description = "Use a custom KMS key to encrypt the secrets in SSM Parameter Store"
   default     = false
 }


### PR DESCRIPTION
# Descriptions
- Update documentation to move `secretsmanager_key` and `ssm_parameter_prefix` as top level variables.
- Fix bug that uses default aws managed ssm key.