### PR TITLE
Allow the authorizer type to be specified

### DIFF
--- a/docs/modules/api_gateway.md
+++ b/docs/modules/api_gateway.md
@@ -85,6 +85,7 @@ The `lambda` attribute map contains:
 * `function_name` - the function name of the lambda to be called
 * `authorizer_result_ttl_in_seconds` - (optional, default to "900") ttl in seconds for an authorizer result.
 * `identity_source` - (optional, default "method.request.header.X-Auth-Token") identity source for an authorizer lambda.
+* `authorizer_type` - (optional, default "TOKEN") type of authorizer determining the payload, other possible values: "REQUEST" and "COGNITO_USER_POOLS".
 
 A `route` mapping can contain:
 

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -29,6 +29,8 @@ locals {
   subroutes = { for key, value in local.routes : key => value if key != "" }
   redeployment_hash = sha1(jsonencode(concat(
     [
+      var.name
+      ], [
       for key, value in aws_api_gateway_resource.rest_api_route_resource : value.id
       ], [
       for key, value in aws_api_gateway_method.rest_api_route_method : value.id

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -110,6 +110,7 @@ resource "aws_api_gateway_authorizer" "authorizer" {
 
   name        = "api-authorizer-${each.key}"
   rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  type        = lookup(var.lambdas[each.key], "authorizer_type", "TOKEN")
   # authorizer_uri looks funny because of https://github.com/hashicorp/terraform-provider-aws/issues/26619
   authorizer_uri                   = replace(data.aws_lambda_function.lambda[each.key].invoke_arn, "/\\:\\d{1,3}\\/invocations/", "/invocations")
   authorizer_credentials           = aws_iam_role.invocation_role.arn


### PR DESCRIPTION
The default authorizer type is `TOKEN`, but that only sends the token value specified by `identity_source` to the authorizer Lambda function, whereas `REQUEST` will send the entire request object, which might be helpful in certain cases.