### PR TITLE
Use relative paths for generated docsify links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
         crossChapter: true,
         crossChapterText: true,
       },
+      relativePath: true,
     }
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
Relative paths in markdown do not work w/ the default docsify settings.

e.g. currently published docs (via #31) @ https://rss-engineering.github.io/terraform/#/modules/security_hub have a relative link to another doc in the same folder:

```md
This should be provisioned together with the [guardduty](./guardduty.md) product.
```

When rendered by docsify, it results in a non-existent destination:

```html
- /#/./guardduty
```

Setting `relativePath: true` will correctly render the link and preserve the ability to navigate `*.md` docs in the Github UI:

```diff
- /#/./guardduty
+/#/modules/guardduty
```

See https://docsify.js.org/#/configuration?id=relativepath

