### PR TITLE
Add 'redeployment_hash' variable to api_gateway module

### DIFF
--- a/docs/modules/api_gateway.md
+++ b/docs/modules/api_gateway.md
@@ -86,6 +86,7 @@ The following arguments are supported:
 * `lambdas` - A mapping of string keys to an attribute mapping. The keys are arbitrary for reference in `root_route` and `route` entries.
 * `set_cloudwatch_role` - A boolean indicating if the API Gateway Cloudwatch role should be set
 * `apigateway_cloudwatch_role_arn` - (optional) If `set_cloudwatch_role` is true, then specifying this will set the specific role. If not provided, a role will be created.
+* `redeployment_hash` - (optional) - Additional entropy variable to ensure a fresh deployment is made when applicable changes are made.
 
 The `lambda` attribute map contains:
 

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -43,7 +43,8 @@ locals {
   level_5_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 5 }
   redeployment_hash = sha1(jsonencode(concat(
     [
-      var.name
+      var.name,
+      var.redeployment_hash
       ], [
       for key, value in aws_api_gateway_resource.rest_api_route_1d_resource : value.id
       ], [

--- a/modules/api_gateway/variables.tf
+++ b/modules/api_gateway/variables.tf
@@ -18,6 +18,11 @@ variable "stage_name" {
   type = string
 }
 
+variable "redeployment_hash" {
+  type = string
+  default = ""
+}
+
 variable "log_retention_in_days" {
   type    = number
   default = 0


### PR DESCRIPTION
The purpose of this new variable is to provide a way to force a new API Gateway deployment even if nothing detectable changes.