### PR TITLE
remove unused local which causes errors when there's no root route

### DIFF
--- a/docs/modules/api_gateway.md
+++ b/docs/modules/api_gateway.md
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `routes` - A mapping of path prefixes to `route` mappings to define the behavior at that path prefix (The leading '/' is cosmetic. Paths can contain up to five levels deep.).
 * `tags` - (optional) A mapping of tags to be applied to all resources.
 * `log_retention_in_days` - (optional, default 0) - number of days to retain logs. 0 (the default) means to never expire logs. Other valid values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653.
-* `lambdas` - A mapping of string keys to an attribute mapping. The keys are arbitrary for reference in `root_route` and `route` entries.
+* `lambdas` - A mapping of string keys to an attribute mapping. The keys are arbitrary for reference in `route` entries.
 * `set_cloudwatch_role` - A boolean indicating if the API Gateway Cloudwatch role should be set
 * `apigateway_cloudwatch_role_arn` - (optional) If `set_cloudwatch_role` is true, then specifying this will set the specific role. If not provided, a role will be created.
 * `redeployment_hash` - (optional) - Entropy variable to trigger a deployment to be made. If omitted, this module will do its best to detect applicable changes.

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -35,7 +35,6 @@ locals {
     "4" = { for key, value in local.level_4_routes : key => aws_api_gateway_resource.rest_api_route_4d_resource[key].id }
     "5" = { for key, value in local.level_5_routes : key => aws_api_gateway_resource.rest_api_route_5d_resource[key].id }
   }
-  root_route = local.routes[""]
   level_1_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 1 && key != "" }
   level_2_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 2 }
   level_3_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 3 }


### PR DESCRIPTION
This isn't referenced anywhere and causes an error if there isn't a route for `/`