### PR TITLE
Hash full resources for apigw redeployment

### DIFF
--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -40,27 +40,17 @@ locals {
   level_3_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 3 }
   level_4_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 4 }
   level_5_routes = { for key, value in local.routes : key => value if length(split("/", key)) == 5 }
-  redeployment_hash = var.redeployment_hash != "" ? var.redeployment_hash : sha1(jsonencode(concat(
-    [
-      var.name,
-      ], [
-      for key, value in aws_api_gateway_resource.rest_api_route_1d_resource : value.id
-      ], [
-      for key, value in aws_api_gateway_resource.rest_api_route_2d_resource : value.id
-      ], [
-      for key, value in aws_api_gateway_resource.rest_api_route_3d_resource : value.id
-      ], [
-      for key, value in aws_api_gateway_resource.rest_api_route_4d_resource : value.id
-      ], [
-      for key, value in aws_api_gateway_resource.rest_api_route_5d_resource : value.id
-      ], [
-      for key, value in aws_api_gateway_method.rest_api_route_method : value.id
-      ], [
-      for key, value in aws_api_gateway_integration.rest_api_route_integration : value.id
-      ], [
-      for key, value in aws_api_gateway_authorizer.authorizer : value.id
-    ]
-  )))
+  redeployment_hash = var.redeployment_hash != "" ? var.redeployment_hash : sha1(jsonencode([
+    var.name,
+    aws_api_gateway_resource.rest_api_route_1d_resource,
+    aws_api_gateway_resource.rest_api_route_2d_resource,
+    aws_api_gateway_resource.rest_api_route_3d_resource,
+    aws_api_gateway_resource.rest_api_route_4d_resource,
+    aws_api_gateway_resource.rest_api_route_5d_resource,
+    aws_api_gateway_method.rest_api_route_method,
+    aws_api_gateway_integration.rest_api_route_integration,
+    aws_api_gateway_authorizer.authorizer,
+  ]))
 }
 
 data "aws_region" "current" {}


### PR DESCRIPTION
Hashing just the `id` is a bit simpler and more predictable but also misses out on a lot of potential changes which should probably be triggering a deployment. [Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment#terraform-resources) indicate that hashing the entire resource is a valid approach here.