### PR TITLE
feat: allow consumer to self-manage lambda permissions

### DIFF
--- a/docs/modules/api_gateway.md
+++ b/docs/modules/api_gateway.md
@@ -93,6 +93,7 @@ The following arguments are supported:
 * `set_cloudwatch_role` - A boolean indicating if the API Gateway Cloudwatch role should be set
 * `apigateway_cloudwatch_role_arn` - (optional) If `set_cloudwatch_role` is true, then specifying this will set the specific role. If not provided, a role will be created.
 * `redeployment_hash` - (optional) - Entropy variable to trigger a deployment to be made. If omitted, this module will do its best to detect applicable changes.
+* `skip_invoke_permissions` - (optional, default `false`) - enable this to manage lambda permissions manually, required if using versioned lambdas.
 
 The `lambda` attribute map contains:
 
@@ -124,3 +125,4 @@ In addition to all arguments above, the following attributes are exported:
 * `stage_url` - The full url of the exposed stage
 * `stage_arn` - The ARN of the exposed stage
 * `log_role_arn` - The cloudwatch log role created if `apigateway_cloudwatch_role_arn` is not supplied
+* `execution_arn` - The execution_arn of the API gateway, usually used as part of the `source_arn` for lambda permissions

--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -126,7 +126,7 @@ resource "aws_api_gateway_authorizer" "authorizer" {
 
 # API_GATEWAY
 resource "aws_lambda_permission" "lambda_invoke_permission" {
-  for_each = var.lambdas
+  for_each = var.skip_invoke_permissions ? {} : var.lambdas
 
   statement_id  = "allow-${var.name}-apigateway-invoke-${each.key}"
   action        = "lambda:InvokeFunction"

--- a/modules/api_gateway/output.tf
+++ b/modules/api_gateway/output.tf
@@ -17,3 +17,7 @@ output "stage_arn" {
 output "log_role_arn" {
   value = var.apigateway_cloudwatch_role_arn != "" ? var.apigateway_cloudwatch_role_arn : aws_iam_role.log_role[0].arn
 }
+
+output "execution_arn" {
+  value = aws_api_gateway_rest_api.rest_api.execution_arn
+}

--- a/modules/api_gateway/variables.tf
+++ b/modules/api_gateway/variables.tf
@@ -46,6 +46,13 @@ variable "lambdas" {
   type = map(map(string))
 }
 
+variable "skip_invoke_permissions" {
+  description = "Set to true to manage lambda invoke permissions outside of this module."
+
+  type    = bool
+  default = false
+}
+
 variable "routes" {
   type = map(map(string))
 }


### PR DESCRIPTION
The built-in management doesn't handle versioned lambdas, and I'm not 100% sure this is the final fix for this problem but the permissions need to be reapplied whenever a new version is published in order for APIGW to have permission to call the newly deployed lambda. Since we don't have direct access to the `aws_lambda_function` resource in the module it's difficult to trigger updates like is shown in the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#with-replace_triggered_by-lifecycle-configuration). This seems like something that shouldn't be the responsibility of this module anyway, so I'm adding a flag to opt-out of the behavior for backwards compatibility.