### PR TITLE
feat: grant permission to invoke lambdas by policy

### DIFF
--- a/docs/modules/api_gateway.md
+++ b/docs/modules/api_gateway.md
@@ -93,7 +93,6 @@ The following arguments are supported:
 * `set_cloudwatch_role` - A boolean indicating if the API Gateway Cloudwatch role should be set
 * `apigateway_cloudwatch_role_arn` - (optional) If `set_cloudwatch_role` is true, then specifying this will set the specific role. If not provided, a role will be created.
 * `redeployment_hash` - (optional) - Entropy variable to trigger a deployment to be made. If omitted, this module will do its best to detect applicable changes.
-* `skip_invoke_permissions` - (optional, default `false`) - enable this to manage lambda permissions manually, required if using versioned lambdas.
 
 The `lambda` attribute map contains:
 

--- a/modules/api_gateway/variables.tf
+++ b/modules/api_gateway/variables.tf
@@ -46,13 +46,6 @@ variable "lambdas" {
   type = map(map(string))
 }
 
-variable "skip_invoke_permissions" {
-  description = "Set to true to manage lambda invoke permissions outside of this module."
-
-  type    = bool
-  default = false
-}
-
 variable "routes" {
   type = map(map(string))
 }


### PR DESCRIPTION
The idea here is that instead of adding permissions on each lambda (and potentially each _version_ of each lambda) we should just grant permissions to the role assumed by APIGW when calling the lambdas, and use wildcards for versioned lambdas. This way, whenever we add a new version of a lambda the APIGW will already have access to invoke it without any permissions changes required.

If we manage invoke permissions using the `aws_lambda_permission` resource, terraform will destroy the permission required for the currently running deployment before the new deployment is created so there will be a moment when traffic is hitting the old lambda but the gateway does not have permission to invoke the old lambda anymore causing a disruption. This also means that rolling back a deployment would fail because the permissions would also need to be updated.