### PR TITLE
fix(*): fix binary media types var

### DIFF
--- a/modules/api_gateway/variables.tf
+++ b/modules/api_gateway/variables.tf
@@ -69,6 +69,6 @@ variable "apigateway_cloudwatch_role_arn" {
 }
 
 variable "binary_media_types" {
-  type    = list()
+  type    = list(string)
   default = []
 }


### PR DESCRIPTION
Fix this error in mass-comm

```
│ Error: Invalid type specification
│ 
│   on .terraform/modules/main.api_gateway.api_gateway/modules/api_gateway/variables.tf line 72, in variable "binary_media_types":
│   72:   type    = list()
│ 
│ The list type constructor requires one argument specifying the element
│ type.
```