### PR TITLE
feat: enable PCI v4.0.1 security hub standard

### DIFF
--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -11,6 +11,11 @@ resource "aws_securityhub_standards_subscription" "cis" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
 }
 
+resource "aws_securityhub_standards_subscription" "pci" {
+  depends_on    = [aws_securityhub_account.security_hub]
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/4.0.1"
+}
+
 resource "aws_securityhub_product_subscription" "guardduty" {
   depends_on  = [aws_securityhub_account.security_hub]
   product_arn = "arn:aws:securityhub:${data.aws_region.current.name}::product/aws/guardduty"


### PR DESCRIPTION
In order to use audit manager effectively for our PCI compliance, we also need to enable the PCI standard in security hub