### PR TITLE
Adding a KMS key for encrypting CloudWatch Logs

### DIFF
--- a/modules/wafv2/main.tf
+++ b/modules/wafv2/main.tf
@@ -215,9 +215,17 @@ data "aws_iam_policy_document" "web_acl_policy_document" {
   }
 }
 
+# `tfsec` reported a LOW severity issue in platform-services-observability
+# CloudWatch Log Group is not encrypted with a customer-managed key (CMK)
+resource "aws_kms_key" "log_group_kms" {
+  description             = "KMS key for encrypting CloudWatch Logs"
+  enable_key_rotation     = true
+}
+
 # CloudWatch Log Group for WAFv2 Logging
 resource "aws_cloudwatch_log_group" "web_acl_log" {
   name  = "aws-waf-logs-${var.stage}_${var.region}_${var.service_name}"
+  kms_key_id = aws_kms_key.log_group_kms.arn
   count = var.enabled
 }
 


### PR DESCRIPTION
While accessing the WAFv2 module in our repo ([platform-services-observability](https://github.com/RSS-Engineering/platform-services-observability/)), we faced this issue during a `tfsec` scan.

This issue can be fixed by adding a CMK for the cloudwatch log group.

```
Result #1 LOW Log group is not encrypted. 
────────────────────────────────────────────────────────────────────────────────
  github.com/RSS-Engineering/terraform/modules/wafv2?ref=53cbaac6891da31d4b4f4bbcecbe36a9b8a120c6/main.tf:219-222
   via infra/sso/main.tf:110-120 (module.wafv2)
────────────────────────────────────────────────────────────────────────────────
  219    resource "aws_cloudwatch_log_group" "web_acl_log" {
  220      name  = "aws-waf-logs-${var.stage}_${var.region}_${var.service_name}"
  221      count = var.enabled
  222    }
────────────────────────────────────────────────────────────────────────────────
          ID aws-cloudwatch-log-group-customer-key
      Impact Log data may be leaked if the logs are compromised. No auditing of who have viewed the logs.
  Resolution Enable CMK encryption of CloudWatch Log Groups

  More Information
  - https://aquasecurity.github.io/tfsec/v1.28.14/checks/aws/cloudwatch/log-group-customer-key/
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#kms_key_id
  - ```