### PR TITLE
chore: disable mostly unused pci4 standard

### DIFF
--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -11,11 +11,6 @@ resource "aws_securityhub_standards_subscription" "cis" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
 }
 
-resource "aws_securityhub_standards_subscription" "pci" {
-  depends_on    = [aws_securityhub_account.security_hub]
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/4.0.1"
-}
-
 resource "aws_securityhub_product_subscription" "guardduty" {
   depends_on  = [aws_securityhub_account.security_hub]
   product_arn = "arn:aws:securityhub:${data.aws_region.current.name}::product/aws/guardduty"


### PR DESCRIPTION
We're moving towards centralized security hub and this entire module probably won't be necessary anymore once that happens. Not all accounts were updated to use a recent enough version of the module to even enable this in the first place, and I'm running into issues where it is being enabled. The standard takes a while to provision, and it's causing terraform to time out.

> Error: waiting for Security Hub Standards Subscription (arn:aws:securityhub:us-east-1:152267171281:subscription/pci-dss/v/4.0.1) create: timeout while waiting for state to become 'READY, INCOMPLETE' (last state: 'PENDING', timeout: 3m0s)

I'm just going to remove it for now, and it can always be manually toggled back on if desired.