### PR TITLE
fix: Remove deprecated stage_description from aws_api_gateway_deployment

### DIFF
--- a/modules/api_gateway/main.tf
+++ b/modules/api_gateway/main.tf
@@ -231,7 +231,6 @@ resource "aws_api_gateway_deployment" "deployment" {
   triggers = {
     redeployment = local.redeployment_hash
   }
-  stage_description = local.redeployment_hash
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Fixes #64.

This just removes setting `stage_description` in the `aws_api_gateway_deployment` resource. The `stage_description` field was deprecated somewhere in version 5 of the aws provider and breaks with version 6 of the aws provider.

Additionally, the `stage_description` currently doesn't appear to do anything as it wasn't even setting the description on the stage resource in the first place. 