### PR TITLE
feat: silently remove security hub management

### DIFF
--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -1,23 +1,42 @@
-resource "aws_securityhub_account" "security_hub" {
-  enable_default_standards  = false
-  control_finding_generator = "SECURITY_CONTROL"
-  auto_enable_controls      = true
+# Rackspace has moved towards centralized/org managed security hub accounts instead
+# This module now exists as a way to transition off of the old model for accounts that
+# migrate
+
+removed {
+  from = aws_securityhub_account.security_hub
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-data "aws_region" "current" {}
+removed {
+  from = aws_securityhub_standards_subscription.cis
 
-resource "aws_securityhub_standards_subscription" "cis" {
-  depends_on    = [aws_securityhub_account.security_hub]
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_securityhub_product_subscription" "guardduty" {
-  depends_on  = [aws_securityhub_account.security_hub]
-  product_arn = "arn:aws:securityhub:${data.aws_region.current.name}::product/aws/guardduty"
+removed {
+  from = aws_securityhub_product_subscription.guardduty
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_securityhub_invite_accepter" "invitee" {
-  count      = var.instance == null ? 0 : 1
-  depends_on = [aws_securityhub_account.security_hub]
-  master_id  = var.admin_account[var.instance]
+# instances with resource keys cannot be "removed"
+# but you can move (to remove the resource key) and then remove them
+moved {
+  from = aws_securityhub_invite_accepter.invitee[0]
+  to = aws_securityhub_invite_accepter.removed
+}
+
+removed {
+  from = aws_securityhub_invite_accepter.removed
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/modules/security_hub/outputs.tf
+++ b/modules/security_hub/outputs.tf
@@ -1,3 +1,6 @@
 output "security_hub" {
-  value = aws_securityhub_account.security_hub
+  value = {
+    id: "",
+    arn: ""
+  }
 }


### PR DESCRIPTION
This PR removes all of the resources under the security_hub module. We've got a org-wide centralized security hub administrator account now which makes all of this unnecessary. After managing it this way for a while, I highly recommend _not_ doing it this way. Not because this is necessarily bad, but org management is just a lot simpler.

Will probably just merge this to main and eventually remove it altogether once there are no more consumers. Our group was the only one consuming this module as far as I know.