### PR TITLE
fix: add removed block for the pci subscription

### DIFF
--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -19,6 +19,14 @@ removed {
 }
 
 removed {
+  from = aws_securityhub_standards_subscription.pci
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
   from = aws_securityhub_product_subscription.guardduty
 
   lifecycle {


### PR DESCRIPTION
Some consumers (like janus-infra) may have an older version of the module which still had PCI enabled. This adds an additional removed block to remove that from state if it exists.