### PR TITLE
Support passing through tags to S3 bucket

### DIFF
--- a/docs/modules/s3_bucket.md
+++ b/docs/modules/s3_bucket.md
@@ -40,6 +40,7 @@ module "test_bucket" {
   source = "git@github.com:RSS-Engineering/terraform//modules/s3_bucket?ref=<commit>"
 
   name              = "testbucket"
+  tags              = {}
   bucket_policies   = [
     data.aws_iam_policy_document.example_policy1.json,
     data.aws_iam_policy_document.example_policy2.json
@@ -62,6 +63,7 @@ data "aws_iam_policy_document" "example_policy2" {
 The following arguments are supported:
 
 - `name` - name of the bucket
+- `tags` - (optional) A mapping of tags to be applied to the S3 bucket.
 - `bucket_policies` - list of additional bucket policies (as a json string) to attach to the bucket
 - `enable_versioning` - whether or not to enable versioning, defaults to `false`
 - `expiration_days` - number of days until objects expire, defaults to `null` for no expiration

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "this" {
   bucket = var.name
+  tags   = var.tags
 }
 
 resource "aws_s3_bucket_ownership_controls" "this" {

--- a/modules/s3_bucket/variables.tf
+++ b/modules/s3_bucket/variables.tf
@@ -49,3 +49,11 @@ variable "additional_expiration_rules" {
     error_message = "All expiration rules must specify either expiration_days or noncurrent_expiration_days"
   }
 }
+
+variable "tags" {
+  type = map(string)
+
+  default = {
+    Terraform = "managed"
+  }
+}


### PR DESCRIPTION
**JIRA:** https://rackspace.atlassian.net/browse/RESUI-1367

**Description:**
**Support passing through tags to S3 bucket.**

Note: The plan is to invoke the S3 bucket creation module in this repo from our GitHub reusable workflow (in the .github repo). This workflow is used by the micro UI starter kit template to create a private bucket with OAC instead of a public S3 bucket.